### PR TITLE
feat: fix config path in bookworm

### DIFF
--- a/roles/raspberrypi/cgroups/tasks/main.yaml
+++ b/roles/raspberrypi/cgroups/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Activating cgroup support
   ansible.builtin.lineinfile:
-    path: /boot/cmdline.txt
+    path: /boot/firmware/cmdline.txt
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true


### PR DESCRIPTION
Raspberry Pi OS Bookworm changes the boot mount path. This adjusts for this.