### PR TITLE
feat: add boot config UART and fan

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -4,6 +4,7 @@
   become: true
   roles:
     - raspberrypi
+    - raspberrypi/bootconfig
     - raspberrypi/cgroups
     - raspberrypi/k3s
     - raspberrypi/longhorn

--- a/group_vars/k3s.yaml
+++ b/group_vars/k3s.yaml
@@ -1,4 +1,10 @@
 ---
+raspberrypi:
+  boot_config:
+    file: /boot/firmware/config.txt
+    add:
+      - dtoverlay=disable-bt
+      - dtoverlay=i2c-fan,emc2301,i2c_csi_dsi
 k3s:
   node_name: "{{ inventory_hostname_short }}"
   version: v1.30.0+k3s1


### PR DESCRIPTION
This adds boot firmware config for enabling the UART port and the PWM fan